### PR TITLE
Game over page improvements

### DIFF
--- a/app/controllers/gameplays_controller.rb
+++ b/app/controllers/gameplays_controller.rb
@@ -8,7 +8,9 @@ class GameplaysController < SessionsController
     @nonplayers = Nonplayer.where(current_level: @current_user.current_level)
   end
 
-  def game_over; end
+  def game_over
+    redirect_to root_path, alert: "You're game isn't over yet!" unless @current_user.current_level.zero?
+  end
 
   def check_game_over
     redirect_to game_over_path, alert: "Game Over: You can't continue the game." if @current_user.current_level.zero?

--- a/app/controllers/gameplays_controller.rb
+++ b/app/controllers/gameplays_controller.rb
@@ -16,6 +16,8 @@ class GameplaysController < SessionsController
 
   def restart
     @current_user.update(current_level: 1, balance: 0, day: 1, hour: 1)
+    Inventory.where(character: @current_user).each(&:delete)
+    @current_user.add_starter_items
     redirect_to root_path, notice: 'Game restarted successfully.'
   end
 end

--- a/app/views/gameplays/game_over.html.erb
+++ b/app/views/gameplays/game_over.html.erb
@@ -5,7 +5,7 @@
         <h1 class="center-text dpfont text-5xl">Game Over!</h1>
         <h3 class="center-text hermitfont py-5">You can't afford to pay your expenses, and you have no time left!</h2>
         <div class="flex flex-row justify-center py-4">
-            <%= button_to 'Restart', restart_game_path, class: 'red-button' %>
+            <%= button_to 'Restart', restart_game_path, class: 'hermitfont red-button' %>
         </div>
     </div>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_01_152438) do
     t.integer "item_to_offer_id"
     t.integer "day", default: 1
     t.integer "hour", default: 1
-    t.integer "era", default: 1
     t.string "uid"
     t.string "provider"
     t.string "email"

--- a/features/game_over_improvements.feature
+++ b/features/game_over_improvements.feature
@@ -7,7 +7,7 @@ I want to the game over page to have good styling and allow me to go back to the
   Background:
     Given the following players exist:
       | name       | occupation | inventory_slots | balance | current_level | uid  | provider      | email         |
-      | Player     | programmer | 5               | 0       | 2             | 5678 | google_oauth2 | test@test.com |
+      | Player     | programmer | 5               | 0       | 0             | 5678 | google_oauth2 | test@test.com |
     Given the following items exist:
       | name   | description                                        | value |
       | wheat  | grainy, fresh from the field                       | 1     |

--- a/features/game_over_improvements.feature
+++ b/features/game_over_improvements.feature
@@ -1,0 +1,39 @@
+Feature: Gameover Page
+
+As a player
+so that I can recover from a game over state
+I want to the game over page to have good styling and allow me to go back to the start with new starter items
+
+  Background:
+    Given the following players exist:
+      | name       | occupation | inventory_slots | balance | current_level | uid  | provider      | email         |
+      | Player     | programmer | 5               | 0       | 2             | 5678 | google_oauth2 | test@test.com |
+    Given the following items exist:
+      | name   | description                                        | value |
+      | wheat  | grainy, fresh from the field                       | 1     |
+      | boots  | sturdy and waterproof, fresh from the cobbler      | 25    |
+      | grapes | -                                                  | 2     |
+    Given the following starter item table exists:
+      | item   | quantity |
+      | wheat  | 10       |
+      | boots  | 1        |
+      | grapes | 3        |
+
+  Scenario: I can see the game over button
+    Given I am logged in as "Player"
+    And I am on the game over page
+    Then I should see "Restart"
+
+  Scenario: I can click the restart button and restart game
+    Given I am logged in as "Player"
+    And I am on the game over page
+    When I click on "Restart"
+    Then I should be on the home page
+    And I should see "Game restarted successfully."
+
+Scenario: After restarting my inventory should not be empty
+    Given I am logged in as "Player"
+    And I am on the game over page
+    When I click on "Restart"
+    Then I should be on the home page
+    And "Player"'s inventory should not be empty

--- a/features/step_definitions/inventory.rb
+++ b/features/step_definitions/inventory.rb
@@ -15,6 +15,11 @@ Then('{string}\'s inventory should be empty') do |character|
   expect(inventory).to be_nil
 end
 
+Then('{string}\'s inventory should not be empty') do |character|
+  inventory = Inventory.find_by(character: Character.find_by(name: character))
+  expect(inventory).not_to be_nil
+end
+
 Then('{string} should have {string} balance') do |character, balance|
   character = Character.find_by(name: character)
   expect(character.balance).to be Integer(balance)

--- a/features/step_definitions/land_on_page.rb
+++ b/features/step_definitions/land_on_page.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+Then('I should be on the home page') do
+  expect(page).to have_current_path root_path
+end
+
+Then('I should be on the login page') do
+  expect(page).to have_current_path welcome_path
+end
+
 Then('I should be on the Players page') do
   expect(current_path).to eq(players_path)
 end

--- a/features/step_definitions/omniauth_steps.rb
+++ b/features/step_definitions/omniauth_steps.rb
@@ -6,10 +6,6 @@ Given('I am not logged in') do
   expect(page).to have_current_path welcome_path
 end
 
-Then('I should be on the login page') do
-  expect(page).to have_current_path welcome_path
-end
-
 Given('I am logged in as {string}') do |name|
   OmniAuth.config.test_mode = true
   player = Player.find_by(name:)
@@ -28,13 +24,4 @@ Given('I am logged in as {string}') do |name|
   visit test_login_path
   expect(page).to have_content('true')
   OmniAuth.config.test_mode = false
-end
-
-Given('I am on the login page') do
-  visit welcome_path
-  expect(page).to have_current_path welcome_path
-end
-
-Then('I should be on the home page') do
-  expect(page).to have_current_path root_path
 end

--- a/features/step_definitions/start_on_page.rb
+++ b/features/step_definitions/start_on_page.rb
@@ -4,6 +4,11 @@ Given('I am on the home page') do
   visit root_path
 end
 
+Given('I am on the login page') do
+  visit welcome_path
+  expect(page).to have_current_path welcome_path
+end
+
 Given('I am on the town page') do
   visit town_path
 end

--- a/spec/controllers/gameplays_controller_spec.rb
+++ b/spec/controllers/gameplays_controller_spec.rb
@@ -58,7 +58,48 @@ RSpec.describe GameplaysController, type: :controller do
       expect(@current_user.balance).to eq(0)
       expect(@current_user.day).to eq(1)
       expect(@current_user.hour).to eq(1)
+
       expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context 'starter items' do
+    before do
+      item1 = Item.create!(name: 'test item', description: 'test', value: 1)
+      item2 = Item.create!(name: 'test item 2', description: 'test', value: 1)
+      @item3 = Item.create!(name: 'test item 3', description: 'test', value: 1)
+
+      @si1 = StarterItem.create!({ item: item1, quantity: 1 })
+      @si2 = StarterItem.create!({ item: item2, quantity: 2 })
+    end
+
+    after do
+      StarterItem.destroy_all
+      Inventory.destroy_all
+      Item.destroy_all
+    end
+
+    describe 'adding starter items' do
+      it 'adds all starting items to a player when they restart' do
+        get :restart
+        @current_user.reload
+
+        inv1 = Inventory.find_by(item: @si1.item, character: @current_user)
+        expect(inv1).not_to be_nil
+        expect(inv1.quantity).to eq(1)
+        inv2 = Inventory.find_by(item: @si2.item, character: @current_user)
+        expect(inv2).not_to be_nil
+        expect(inv2.quantity).to eq(2)
+      end
+
+      it 'removes all previous items when restarting' do
+        Inventory.create!(item: @item3, character: @current_user, quantity: 4)
+        get :restart
+        @current_user.reload
+
+        inv3 = Inventory.find_by(item: @item3, character: @current_user)
+        expect(inv3).to be_nil
+      end
     end
   end
 end

--- a/spec/controllers/gameplays_controller_spec.rb
+++ b/spec/controllers/gameplays_controller_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe GameplaysController, type: :controller do
       get :town
       expect(response).to redirect_to(game_over_path)
     end
+    it 'should redirect to home if current_level is not zero' do
+      session[:user_id] = @current_user.id
+      get :game_over
+      expect(response).to redirect_to(root_path)
+    end
   end
 
   describe 'restart' do


### PR DESCRIPTION
Adds starter items to restarted players, and prevents the game-over page from being visited if the player is not in a game-over state.